### PR TITLE
Switch to a simpler 'latest.json' scheme

### DIFF
--- a/src/common/download.py
+++ b/src/common/download.py
@@ -124,8 +124,15 @@ def get_latest_os_info():
         debugger('Latest Kano OS image is {}'.format(latest_json['filename']))
         time.sleep(1)
 
+        image_url = '{base_url}{filename}'.format(
+            base_url=latest_json['base_url'],
+            filename=latest_json['filename'])
+
+        gz_url = '{image_url}.gz'.format(image_url=image_url)
+
         # use the url for the latest os version to get info about the image
-        response = urllib2.urlopen(latest_json['url'] + '.json')
+        image_info_json = '{image_url}.json'.format(image_url=image_url)
+        response = urllib2.urlopen(image_info_json)
         os_json = json.load(response)
 
         # give the server some time to breathe between requests
@@ -135,6 +142,11 @@ def get_latest_os_info():
         debugger('[ERROR] Downloading OS info failed')
         return None
 
-    # merge the two jsons and return a single info dict result
-    os_info = {key: value for (key, value) in (latest_json.items() + os_json.items())}
+    # merge the two jsons, add derived values and return a single info dict
+    os_info = dict(latest_json.items() + os_json.items() +
+                   [
+                       ('image_url', image_url),
+                       ('url', gz_url)
+                   ])
+
     return os_info


### PR DESCRIPTION
Recently there was a change with the way that the Kano build servers
handled building of the Kano OS image, allowing building of 'flavour'
images but also providing opportunity for refactoring. During this
refactoring, the convention for naming of the generated the OS info JSON
changed to reflect the new ability to produce '.zip' files of the OS.
This fix resolves these troubles.

The 'latest.json' file on the server contains lots of information which
can be inferred from just the server location and the image name. This
file is currently being maintained manually whenever a new image is
released so reducing the number of changes required is preferential.
Thus in fixing the image naming convention issues, a switch to using a
simpler 'latest.json' file is implemented

cc @carolineclark @pazdera @radujipa 