### PR TITLE
Fix unmount osx, don't try to eject

### DIFF
--- a/bin/kano-burner
+++ b/bin/kano-burner
@@ -260,7 +260,10 @@ class BurnerBackendThread(QtCore.QThread):
         # this process differs slightly depending on the platform running it
         debugger('Preparing {} for burning..'.format(self.selected_disk))
         self.showStage('Preparing disk for burning..')
-        prepare_disk(self.selected_disk, self.showDescription)
+        error = prepare_disk(self.selected_disk, self.showDescription)
+        if error:
+            self.showFinish(error)
+            return
 
         # Step 3: burn the OS image onto the selected disk
         debugger('Burning image to SD card on ' + self.selected_disk)

--- a/bin/kano-burner
+++ b/bin/kano-burner
@@ -278,7 +278,10 @@ class BurnerBackendThread(QtCore.QThread):
         debugger('Ejecting disk..')
         self.showStage('Waiting for things to settle..')
         time.sleep(5)  # wait for dd to mount the disk back
-        eject_disk(self.selected_disk)
+        error = eject_disk(self.selected_disk)
+        if error:
+            self.showfinish(error)
+            return
 
         # Finally, show success messsage, notify UI of finish, and return an empty error
         self.showStage("Kano OS has successfully been burned. Let's go!")

--- a/bin/kano-burner
+++ b/bin/kano-burner
@@ -48,19 +48,19 @@ from src.common.paths import temp_path
 # Detect OS platform and import appropriate modules
 if platform.system() == 'Darwin':
     debugger('Mac OS detected')
-    from src.osx.burn import start_burn_process
+    from src.osx.burn import start_burn_process, final_message
     from src.osx.disk import get_disks_list, prepare_disk, eject_disk
     from src.osx.dependency import check_dependencies, request_admin_privileges
 
 elif platform.system() == 'Linux':
     debugger('Linux OS detected')
-    from src.linux.burn import start_burn_process
+    from src.linux.burn import start_burn_process, final_message
     from src.linux.disk import get_disks_list, prepare_disk, eject_disk
     from src.linux.dependency import check_dependencies, request_admin_privileges
 
 elif platform.system() == 'Windows':
     debugger('Windows OS detected')
-    from src.windows.burn import start_burn_process
+    from src.windows.burn import start_burn_process, final_message
     from src.windows.disk import get_disks_list, prepare_disk, eject_disk
     from src.windows.dependency import check_dependencies, request_admin_privileges
 
@@ -146,11 +146,12 @@ class BurnerGUI(UI):
         time.sleep(1)  # very odd fix - Qt thread is killed without it
 
     # This method is called when the backendThread finishes
-    def onBackendFinish(self, error):
-        if error:
-            self.showError(error)
+    def onBackendFinish(self, message):
+        if 'success' in message:
+            self.showFinishScreen(message)
         else:
-            self.showScreen(self.finishScreen)
+            self.showError(message)
+
 
     # @Override
     # This method is called when the TRY AGAIN button is clicked
@@ -197,7 +198,7 @@ class BurnerDependencyThread(QtCore.QThread):
         if error:
             self.showFinish(error)
         else:
-            self.notifyFinish.emit(dict())
+            self.showFinish(dict({}))
 
 
 class BurnerBackendThread(QtCore.QThread):
@@ -211,7 +212,7 @@ class BurnerBackendThread(QtCore.QThread):
     in turn is then responsible for displaying the data e.g. burn speed.
 
     From a top level, the back-end does four things: downloads the OS,
-    prepares the disk for burning, burns the OS, and finally ejects
+    prepares the disk for burning, burns the OS. The user must then eject
     the disk for safe removal. These processes will use the signals to
     report progress to the UI and an erroneous or successful completion.
     '''
@@ -239,9 +240,9 @@ class BurnerBackendThread(QtCore.QThread):
         self.notifyProgress.emit(progress)
         self.notifyDescription.emit(text)
 
-    def showFinish(self, error):
+    def showFinish(self, message):
         # this signal notifies whether we finishes sucessfully or with an error
-        self.notifyFinish.emit(error)
+        self.notifyFinish.emit(message)
 
     def run(self):
         # Step 1: download the latest Kano OS image
@@ -273,19 +274,9 @@ class BurnerBackendThread(QtCore.QThread):
             self.showFinish(error)
             return
 
-        # Step 4: eject selected disk so the user can unplug safely
-        # on OSX, the disk will automatically be mounted back after dd finishes
-        debugger('Ejecting disk..')
-        self.showStage('Waiting for things to settle..')
-        time.sleep(5)  # wait for dd to mount the disk back
-        error = eject_disk(self.selected_disk)
-        if error:
-            self.showfinish(error)
-            return
-
         # Finally, show success messsage, notify UI of finish, and return an empty error
         self.showStage("Kano OS has successfully been burned. Let's go!")
-        self.notifyFinish.emit(dict())
+        self.showFinish({'success': True, 'title': final_message, 'description': "Kano OS has successfully been burned. Let's go!"})
 
 
 def main():

--- a/src/common/errors.py
+++ b/src/common/errors.py
@@ -43,3 +43,7 @@ BURN_ERROR = {
     'title': 'Burning Kano OS failed..',
     'description': 'Make sure the SD card is still correctly inserted and try again'
 }
+UNMOUNT_ERROR = {
+    'title': 'There was an error unmounting the disk..',
+    'description': 'Make sure the you selected the right disk, and try again'
+}

--- a/src/common/errors.py
+++ b/src/common/errors.py
@@ -47,3 +47,11 @@ UNMOUNT_ERROR = {
     'title': 'There was an error unmounting the disk..',
     'description': 'Make sure the you selected the right disk, and try again'
 }
+FORMAT_ERROR = {
+    'title': 'There was an error formatting the disk..',
+    'description': 'Maybe it is write protected?'
+}
+EJECT_ERROR = {
+    'title': 'There was an error ejecting the disk..',
+    'description': 'Please eject it manually.'
+}

--- a/src/common/ui.py
+++ b/src/common/ui.py
@@ -137,6 +137,7 @@ class UI(QtGui.QWidget):
         container = self.createContainer(x, y)
 
         self.finishLabel = container.addLabel("Kano OS has successfully been burned. Let's go!", LABEL_CSS_TITLE)
+        self.finishDescriptionLabel = container.addLabel('description', LABEL_CSS_DESCRIPTION)
         self.FinishButton = container.addButton("FINISH", self.onFinishClick)
         return container
 
@@ -168,6 +169,13 @@ class UI(QtGui.QWidget):
         self.errorTitleLabel.setText(error['title'])
         self.errorDescriptionLabel.setText(error['description'])
         self.showScreen(self.errorScreen)
+
+    def showFinishScreen(self, message=None):
+        if 'title' in message:
+            self.finishLabel.setText(message['title'])
+        if 'description' in message:
+            self.finishDescriptionLabel.setText(message['description'])
+        self.showScreen(self.finishScreen)
 
     def setProgress(self, progress):
         self.progressBar.setValue(progress)

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -31,8 +31,10 @@ BYTES_IN_GIGABYTE = 1000000000
 
 
 # The URL used to download information about the lastest OS release
+#LATEST_OS_INFO_URL = 'http://dev.kano.me/temp/burner_test.json' 
 LATEST_OS_INFO_URL = 'http://downloads.kano.me/public/latest.json'
 
+#debf = open("/tmp/kano_burner_{}.log".format(os.getpid()),"w")
 
 def debugger(text):
     # if we are running from a PyInstaller bundle, print debug to file

--- a/src/linux/burn.py
+++ b/src/linux/burn.py
@@ -30,6 +30,8 @@ from src.common.utils import run_cmd, calculate_eta, debugger, BYTES_IN_MEGABYTE
 from src.common.errors import BURN_ERROR
 from src.common.paths import temp_path
 
+final_message = "PLEASE EJECT THE SD CARD!"
+
 
 def start_burn_process(os_info, disk, report_progress_ui):
     '''

--- a/src/linux/disk.py
+++ b/src/linux/disk.py
@@ -19,6 +19,11 @@
 
 
 from src.common.utils import run_cmd, debugger, BYTES_IN_GIGABYTE
+from src.common.errors import UNMOUNT_ERROR
+
+
+class unmount_error(Exception):
+    pass
 
 
 def get_disks_list():
@@ -115,11 +120,14 @@ def prepare_disk(disk_id, report_ui):
     and format the disk before the burning process starts.
     '''
 
-    report_ui('unmounting disk')
-    unmount_disk(disk_id)
+    try:
+        report_ui('unmounting disk')
+        unmount_disk(disk_id)
 
-    report_ui('formating disk')
-    format_disk(disk_id)
+        report_ui('formating disk')
+        format_disk(disk_id)
+    except unmount_error:
+        return UNMOUNT_ERROR
 
 
 def unmount_disk(disk_id):
@@ -133,6 +141,7 @@ def unmount_disk(disk_id):
         debugger('disk {} successfully unmounted'.format(disk_id))
     else:
         debugger('[ERROR] ' + error.strip('\n'))
+        raise unmount_error
 
 
 def unmount_volumes(disk_id):

--- a/src/mk_burner_test.sh
+++ b/src/mk_burner_test.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# mk_burner_test.sh
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+
+# make short a burner file suitable for testing, 
+
+N=burner_test
+F=${N}.img
+
+
+dd if=/dev/urandom bs=1M count=10 of=$(F)
+
+gzip ${F}
+zcat ${F}.gz >${F}
+rm ${F}.zip
+zip ${F}.zip ${F}
+echo >${F}.json {
+echo >>${F}.json ' "uncompressed_md5":"'$(md5sum ${F} |cut -d ' ' -f 1)'"',
+echo >>${F}.json ' "compressed_md5":"'$(md5sum ${F}.gz | cut -d ' ' -f 1)'"',
+echo >>${F}.json ' "zip_md5":"'$(md5sum ${F}.zip | cut -d ' ' -f 1)'"',
+echo >>${F}.json ' "uncompressed_size":'$(stat -c "%s" ${F}),
+echo >>${F}.json ' "compressed_size":'$(stat -c "%s" ${F}.gz),
+echo >>${F}.json ' "zip_size":'$(stat -c "%s" ${F}.zip)
+
+echo >>${F}.json }
+
+cat >${N}.json <<EOF
+{
+  "name": "Kano OS",
+  "version": "Beta 1.3.4",
+  "base_url": "http://dev.kano.me/temp/",
+  "filename": "burner_test.img",
+  "url": "http://dev.kano.me/temp/burner_test.img.gz",
+  "url_zip": "http://dev.kano.me/temp/burner_test.img.zip"
+}
+EOF

--- a/src/osx/burn.py
+++ b/src/osx/burn.py
@@ -30,6 +30,7 @@ from src.common.utils import run_cmd, calculate_eta, debugger, BYTES_IN_MEGABYTE
 from src.common.errors import BURN_ERROR
 from src.common.paths import temp_path
 
+final_message = "PLEASE EJECT THE SD CARD!"
 
 def start_burn_process(os_info, disk, report_progress_ui):
     '''

--- a/src/osx/burn.py
+++ b/src/osx/burn.py
@@ -69,40 +69,91 @@ def start_burn_process(os_info, disk, report_progress_ui):
 
 
 def burn_kano_os(path, disk, size, return_queue, report_progress_ui):
-    cmd = 'gzip -dc {} | dd of={} bs=4m'.format(path, disk)
-    process = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE)
-
     failed = False
     unparsed_line = ''
+    try:
+        gzip_cmd = 'gzip -dc {}'.format(path)
+        dd_cmd = 'dd of={} bs=4m'.format(disk)
+        gzip_process = subprocess.Popen(gzip_cmd,
+                                        stderr=subprocess.PIPE,
+                                        stdout=subprocess.PIPE,
+                                        shell=True)
+        dd_process = subprocess.Popen(dd_cmd, stderr=subprocess.PIPE,
+                                      stdin=gzip_process.stdout,
+                                      stdout=subprocess.PIPE,
+                                      shell=True)
+        gzip_process.stdout.close()
 
-    # as long as Popen is running, read it's stderr line by line
-    # each time an INFO signal is sent to dd, it outputs 3 lines
-    # and we are only interested in the last one i.e. 'x bytes written in y seconds'
-    for line in iter(process.stderr.readline, ''):
-        if 'bytes' in line:
-            try:
-                parts = line.split()
+        gzip_err_output = Queue.Queue()
 
-                written_bytes = float(parts[0])
-                progress = int(written_bytes / size * 100)
+        def gzip_read(gzip_file, return_queue):
+            lines = gzip_file.readlines()
+            return_queue.put(lines)
 
-                speed = float(parts[6][1:]) / BYTES_IN_MEGABYTE
+        gzip_thread = threading.Thread(target=gzip_read,
+                                       args=(gzip_process.stderr, gzip_err_output))
+        gzip_thread.start()
 
-                eta = calculate_eta(written_bytes, size, int(parts[6][1:]))
 
-                report_progress_ui(progress, 'speed {0:.2f} MB/s  eta {1:s}  completed {2:d}%'
-                                   .format(speed, eta, progress))
-            except:
-                unparsed_line = line
+        # as long as Popen is running, read it's stderr line by line
+        # each time an INFO signal is sent to dd, it outputs 3 lines
+        # and we are only interested in the last one i.e. 'x bytes written in y seconds'
+        for line in iter(dd_process.stderr.readline, ''):
+            if 'bytes' in line:
+                try:
+                    parts = line.split()
 
-        # watch out for an error output from dd
-        if 'error' in line.lower() or 'invalid' in line.lower():
-            debugger('[ERROR] ' + line)
+                    written_bytes = float(parts[0])
+                    progress = int(written_bytes / size * 100)
+
+                    speed = float(parts[6][1:]) / BYTES_IN_MEGABYTE
+
+                    eta = calculate_eta(written_bytes, size, int(parts[6][1:]))
+
+                    report_progress_ui(progress, 'speed {0:.2f} MB/s  eta {1:s}  completed {2:d}%'
+                                       .format(speed, eta, progress))
+                except:
+                    unparsed_line = line
+
+            # watch out for an error output from dd
+            if 'error' in line.lower() or 'invalid' in line.lower():
+                debugger('[ERROR] ' + line)
+                failed = True
+
+        # dd has closed its stdout, so everything should have finished.
+        # But check anyway.
+
+        dd_process.poll()
+        if dd_process.returncode is None:
+            dd_process.kill()
+            dd_process.poll()
+
+        gzip_process.poll()
+        if gzip_process.returncode is None:
+            gzip_process.kill()
+            gzip_process.poll()
+
+        if dd_process.returncode != 0:
+            debugger('[ERROR] dd returned error code {}'
+                     .format(dd_process.returncode))
             failed = True
 
-    # make sure the progress bar is filled and show an appropriate message
-    # if we failed, the UI will immediately show the error screen
-    report_progress_ui(100, 'burning finished successfully')
+        if gzip_process.returncode != 0:
+            debugger('[ERROR] dd returned error code {}'
+                     .format(dd_process.returncode))
+            failed = True
+
+        gzip_thread.join(100)
+        gzip_stderr = gzip_err_output.get()
+
+        debugger("gzip output: " + str(gzip_stderr))
+
+        # make sure the progress bar is filled and show an appropriate message
+        # if we failed, the UI will immediately show the error screen
+        report_progress_ui(100, 'burning finished successfully')
+    except Exception as e:
+        debugger(str(e))
+        failed = True
 
     # making sure we log anything nasty that has happened
     if unparsed_line:

--- a/src/osx/burn.py
+++ b/src/osx/burn.py
@@ -126,12 +126,12 @@ def burn_kano_os(path, disk, size, return_queue, report_progress_ui):
         dd_process.poll()
         if dd_process.returncode is None:
             dd_process.kill()
-            dd_process.poll()
+            dd_process.wait()
 
         gzip_process.poll()
         if gzip_process.returncode is None:
             gzip_process.kill()
-            gzip_process.poll()
+            gzip_process.wait()
 
         if dd_process.returncode != 0:
             debugger('[ERROR] dd returned error code {}'
@@ -139,8 +139,8 @@ def burn_kano_os(path, disk, size, return_queue, report_progress_ui):
             failed = True
 
         if gzip_process.returncode != 0:
-            debugger('[ERROR] dd returned error code {}'
-                     .format(dd_process.returncode))
+            debugger('[ERROR] gzip returned error code {}'
+                     .format(gzip_process.returncode))
             failed = True
 
         gzip_thread.join(100)

--- a/src/osx/disk.py
+++ b/src/osx/disk.py
@@ -19,10 +19,10 @@
 
 
 from src.common.utils import run_cmd, debugger, BYTES_IN_GIGABYTE
-from src.common.errors import UNMOUNT_ERROR
+from src.common.errors import UNMOUNT_ERROR, FORMAT_ERROR, EJECT_ERROR
 
 
-class unmount_error(Exception):
+class disk_error(Exception):
     pass
 
 
@@ -115,8 +115,8 @@ def prepare_disk(disk_id, report_ui):
         # OSX mounts the disk back after formatting
         report_ui('unmounting disk')
         unmount_disk(disk_id)
-    except unmount_error:
-        return UNMOUNT_ERROR
+    except disk_error as e:
+        return e.args[0]
 
 
 def unmount_disk(disk_id):
@@ -126,8 +126,8 @@ def unmount_disk(disk_id):
     if not return_code:
         debugger('{} successfully unmounted'.format(disk_id))
     else:
-        debugger('[ERROR] ' + error.strip('\n'))
-        raise unmount_error
+        debugger('[ERROR: {}] {}'.format(cmd,  error.strip('\n')))
+        raise disk_error(UNMOUNT_ERROR)
 
 
 def format_disk(disk_id):
@@ -137,7 +137,8 @@ def format_disk(disk_id):
     if not return_code:
         debugger('{} successfully erased and formatted'.format(disk_id))
     else:
-        debugger('[ERROR] ' + error.strip('\n'))
+        debugger('[ERROR: {}] {}'.format(cmd, error.strip('\n')))
+        raise disk_error(FORMAT_ERROR)
 
 
 def eject_disk(disk_id):
@@ -151,5 +152,7 @@ def eject_disk(disk_id):
 
     if not return_code:
         debugger('{} successfully ejected'.format(disk_id))
+        return None
     else:
-        debugger('[ERROR] ' + error.strip('\n'))
+        debugger('[ERROR: {}] {}'.format(cmd, error.strip('\n')))
+        return EJECT_ERROR

--- a/src/osx/disk.py
+++ b/src/osx/disk.py
@@ -19,6 +19,11 @@
 
 
 from src.common.utils import run_cmd, debugger, BYTES_IN_GIGABYTE
+from src.common.errors import UNMOUNT_ERROR
+
+
+class unmount_error(Exception):
+    pass
 
 
 def get_disks_list():
@@ -100,15 +105,18 @@ def prepare_disk(disk_id, report_ui):
     and format the disk before the burning process starts.
     '''
 
-    report_ui('unmounting disk')
-    unmount_disk(disk_id)
+    try:
+        report_ui('unmounting disk')
+        unmount_disk(disk_id)
 
-    report_ui('formating disk')
-    format_disk(disk_id)
+        report_ui('formating disk')
+        format_disk(disk_id)
 
-    # OSX mounts the disk back after formatting
-    report_ui('unmounting disk')
-    unmount_disk(disk_id)
+        # OSX mounts the disk back after formatting
+        report_ui('unmounting disk')
+        unmount_disk(disk_id)
+    except unmount_error:
+        return UNMOUNT_ERROR
 
 
 def unmount_disk(disk_id):
@@ -119,6 +127,7 @@ def unmount_disk(disk_id):
         debugger('{} successfully unmounted'.format(disk_id))
     else:
         debugger('[ERROR] ' + error.strip('\n'))
+        raise unmount_error
 
 
 def format_disk(disk_id):

--- a/src/windows/burn.py
+++ b/src/windows/burn.py
@@ -29,6 +29,8 @@ from src.common.paths import _7zip_path, _dd_path, temp_path
 # used to calculate burning speed
 last_written_mb = 0
 
+final_message = ""
+
 
 def start_burn_process(os_info, disk, report_progress_ui):
     '''


### PR DESCRIPTION
This PR:
  - removes automatic eject on OSx. This only worked sometimes because it depends on how long OSx takes to remount. Therefore it is simpler to instruct the customer to do this. 
  - Adds error checking. In particular, if we fail to unmount a disk, which likely means we are about to overwrite something important. Also we examine the result codes from dd and gzip.