### PR TITLE
Fix to kill aria2 when download is finished, to allow retry to work.

### DIFF
--- a/src/common/download.py
+++ b/src/common/download.py
@@ -52,6 +52,9 @@ class Downloader(SmartDL):
         # the default method now needs to also report whether it was killed or not
         return not self._killed and SmartDL.isFinished(self)
 
+    def close(self):
+        pass  # only needed for aria2
+
 
 def download_kano_os(report_progress_ui, get_downloader):
     '''
@@ -105,6 +108,7 @@ def download_kano_os(report_progress_ui, get_downloader):
     if downloader.isSuccessful():
         debugger('Downloading successfully finished and md5 check passed')
         report_progress_ui(100, 'download completed')
+        downloader.close()
         return os_info, None
 
     else:
@@ -114,6 +118,8 @@ def download_kano_os(report_progress_ui, get_downloader):
             if isinstance(error, HashFailedException):
                 debugger('[ERROR] MD5 verification failed')
                 return None, MD5_ERROR
+
+        downloader.close()
 
         # for any other errors, report a general message
         debugger('[ERROR] Downloading Kano image failed')


### PR DESCRIPTION
This PR makes the burner close aria2 after downloading, in case it needs to retry because the sd card didn't work etc. Without this retrying fails because we end up with two instances of aria2.