### PR TITLE
Burner logging

### DIFF
--- a/bin/kano-burner
+++ b/bin/kano-burner
@@ -38,9 +38,9 @@ if __name__ == '__main__' and __package__ is None:
 
 from PyQt4 import QtGui, QtCore
 from src.common.ui import UI
-from src.common.widgets import DisclaimerDialog
+from src.common.widgets import DisclaimerDialog, LogReportDialog
 from src.common.download import download_kano_os
-from src.common.utils import delete_dir, debugger
+from src.common.utils import delete_dir, debugger, get_log, submit_log
 from src.common.errors import NO_DISKS_ERROR
 from src.common.paths import temp_path
 
@@ -166,6 +166,7 @@ class BurnerGUI(UI):
     # @Override
     # This method is called when the TRY AGAIN button is clicked
     def onRetryClick(self):
+        self.success = False # The user might have succeeded once but another burn has clearly not worked
         self.disksComboBox.restore()
         self.progressBar.reset()
         self.startButton.setEnabled(False)
@@ -175,11 +176,26 @@ class BurnerGUI(UI):
     # @Override
     # This method is called when the FINISH! button is clicked
     def onFinishClick(self):
+        self.success = True
         self.close()
 
     # @Override
     # This method is called when the application is closing
     def onFinish(self):
+        if not self.success:
+            log = get_log()
+            if log is not None:
+                print "App closed without a burn, offering the chance to send logs"
+                # launch disclaimer dialog - the accepted() method returns
+                # when the user clicks one of the buttons in the dialog
+                logReport = LogReportDialog(self, log)
+                if not logReport.accepted():
+                    debugger('logReport was canceled')
+                else:
+                    debugger("submitting")
+                    submit_log(log, "noreply@kano.me")
+                    debugger("Submitted")
+
         debugger('Removing temp files')
         delete_dir(temp_path)  # only useful when running from source
 
@@ -288,8 +304,25 @@ class BurnerBackendThread(QtCore.QThread):
         self.showStage("Kano OS has successfully been burned. Let's go!")
         self.showFinish({'success': True, 'title': final_message, 'description': "Kano OS has successfully been burned. Let's go!"})
 
+def log_excepthook(exc_class, exc_value, tb):
+    import traceback
+
+    tb_txt = ''.join(traceback.format_tb(tb))
+    try:
+        (filename, number, function, line_text) = traceback.extract_tb(tb)[-1]
+        exc_txt = "{} line {} function {} [{}]".format(
+            filename, number, function, line_text)
+    except:
+        exc_txt = ""
+
+    debugger("Unhandled exception")
+    debugger("Unhandled exception '{}' at {} {}".format(exc_value, exc_txt, tb_txt))
+    sys.__excepthook__(exc_class, exc_value, tb)
+
 
 def main():
+    sys.excepthook = log_excepthook
+    
     # start the UI event handling loop
     app = QtGui.QApplication(sys.argv)
     burnerUI = BurnerGUI()

--- a/bin/kano-burner
+++ b/bin/kano-burner
@@ -193,7 +193,11 @@ class BurnerGUI(UI):
                     debugger('logReport was canceled')
                 else:
                     debugger("submitting")
-                    submit_log(log, "noreply@kano.me")
+                    addr = logReport.getEmail()
+                    if not addr:
+                        addr = "noreply@kano.me"
+                    debugger("Email: "+addr)
+                    submit_log(log, addr)
                     debugger("Submitted")
 
         debugger('Removing temp files')

--- a/build/osx/mkdmg.sh
+++ b/build/osx/mkdmg.sh
@@ -3,6 +3,6 @@ date=$(date +%d%m%y)
 rm -rf Kano_Burner
 mkdir Kano_Burner
 mv "./app/Kano Burner/Kano Burner.app" Kano_Burner
-hdiutil create "./app/Kano Burner/Kano Burner OSx v2 rc${date} ${commit}.dmg" -srcfolder Kano_Burner -ov
+hdiutil create "./app/Kano Burner/Kano Burner OSx rc${date} ${commit}.dmg" -srcfolder Kano_Burner -ov
 
 

--- a/src/common/errors.py
+++ b/src/common/errors.py
@@ -17,7 +17,7 @@ INTERNET_ERROR = {
 }
 FREE_SPACE_ERROR = {
     'title': 'Insufficient available space..',
-    'description': 'Please ensure you have at least 600 MB available space locally'
+    'description': 'Please ensure you have at least 4.5 GB available space locally'
 }
 TOOLS_ERROR = {
     'title': 'Missing some tools..',

--- a/src/common/ui.py
+++ b/src/common/ui.py
@@ -54,6 +54,7 @@ class UI(QtGui.QWidget):
 
     def __init__(self):
         super(UI, self).__init__()
+        self.success = False # To allow the chance to offer feedback if the burn fails
         self.initUI()
 
     def initUI(self):

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -32,7 +32,7 @@ from src.common.paths import temp_path
 BYTES_IN_MEGABYTE = 1000000
 BYTES_IN_GIGABYTE = 1000000000
 
-BURNER_VERSION = 2
+BURNER_VERSION = 3
 
 # Path for submitting feedback
 FEEDBACK_URL = "http://api.kano.me/feedback"

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -90,7 +90,7 @@ def submit_log(log, email):
     }
     data = urlencode(payload)
     debugger("URL: "+FEEDBACK_URL+data)
-    #content = urlopen(url=FEEDBACK_URL, data=data).read()
+    content = urlopen(url=FEEDBACK_URL, data=data).read()
     debugger(content)
 
 

--- a/src/common/widgets.py
+++ b/src/common/widgets.py
@@ -323,7 +323,17 @@ class LogReportDialog(QtGui.QDialog):
         heading.setObjectName("dialogTitle")
         load_css_for_widget(heading, os.path.join(css_path, 'label.css'))
 
-        textview = self.addTextEdit()
+        self.emailMessage = "Optionally enter email address"
+
+        emailentry = self.addTextEdit(text=self.emailMessage, readOnly=False, oneLine=True)
+        textview = self.addTextEdit(self.log, startsVisible=False)
+        self.textview = textview
+        self.emailentry = emailentry
+
+        self.logButton = QtGui.QPushButton("View Log")
+        self.logButton.clicked.connect(self.toggleLog)
+        self.logButton.setObjectName("dialogOk")
+        load_css_for_widget(self.logButton, os.path.join(css_path, 'button.css'))
 
         self.okButton = QtGui.QPushButton("OK")
         self.okButton.clicked.connect(self.accept)
@@ -337,6 +347,8 @@ class LogReportDialog(QtGui.QDialog):
 
         mainLayout = QtGui.QVBoxLayout()
         hbox = QtGui.QHBoxLayout()
+        hbox.addSpacing(20)
+        hbox.addWidget(self.logButton)
         hbox.addSpacing(80)
         hbox.addWidget(self.okButton)
         hbox.addSpacing(20)
@@ -345,21 +357,35 @@ class LogReportDialog(QtGui.QDialog):
 
         mainLayout.setSpacing(20)
         mainLayout.addWidget(heading)
+        mainLayout.addWidget(emailentry)
         mainLayout.addWidget(textview)
         mainLayout.addLayout(hbox)
 
+
         self.setLayout(mainLayout)
+        cancelButton.setFocus()
 
+    def toggleLog(self):
+        self.textview.setVisible(not self.textview.isVisible())
 
-    def addTextEdit(self):
-        textEdit = QtGui.QTextEdit()
+    def getEmail(self):
+        return self.emailentry.text()
+
+    def addTextEdit(self, text, readOnly=True, startsVisible=True, oneLine=False):
+        if oneLine:
+            textEdit = QtGui.QLineEdit()
+        else:
+            textEdit = QtGui.QTextEdit()
         load_css_for_widget(textEdit, os.path.join(css_path, 'textedit.css'))
 
-        text = self.log
+        if readOnly:
+            textEdit.setText(text)
+        else:
+            textEdit.setPlaceholderText(text)
 
-        textEdit.setText(text)
-        textEdit.setReadOnly(True)
+        textEdit.setReadOnly(readOnly)
         textEdit.setGeometry(100, 100, 800, 600)
+        textEdit.setVisible(startsVisible)
 
         return textEdit
 

--- a/src/common/widgets.py
+++ b/src/common/widgets.py
@@ -15,7 +15,7 @@
 
 import os
 from PyQt4 import QtCore, QtGui
-from src.common.utils import load_css_for_widget, read_file_contents
+from src.common.utils import load_css_for_widget, read_file_contents, debugger
 from src.common.paths import images_path, css_path, base_path
 
 
@@ -291,6 +291,81 @@ class DisclaimerDialog(QtGui.QDialog):
     def accepted(self):
         '''
         This method is used by the BurnerGUI when the user clicks BURN!
+
+        We popup the dialog, wait for the user to click one of the buttons,
+        and return whether the user accepted the disclaimer.
+        '''
+
+        response = self.exec_()
+        return response == QtGui.QDialog.Accepted
+
+
+class LogReportDialog(QtGui.QDialog):
+    '''
+    This is a custom popup dialog which contains a title, textedit,
+    a checkbox, and two buttons to accept or cancel.
+
+    We show a disclaimer before starting the burning process, informing
+    the user again about the dangers of overwriting disks.
+    '''
+
+    def __init__(self, parent, logtext):
+        super(LogReportDialog, self).__init__(parent)
+
+        self.log = logtext
+
+        palette = self.palette()
+        palette.setColor(self.backgroundRole(), QtGui.QColor(255, 255, 255))
+        self.setPalette(palette)
+
+        self.setWindowTitle("Sorry we didn't get to finish burning your SD card")
+        heading = QtGui.QLabel("Want to send us the logs to allow us to improve?")
+        heading.setObjectName("dialogTitle")
+        load_css_for_widget(heading, os.path.join(css_path, 'label.css'))
+
+        textview = self.addTextEdit()
+
+        self.okButton = QtGui.QPushButton("OK")
+        self.okButton.clicked.connect(self.accept)
+        self.okButton.setObjectName("dialogOk")
+        load_css_for_widget(self.okButton, os.path.join(css_path, 'button.css'))
+
+        cancelButton = QtGui.QPushButton("CANCEL")
+        cancelButton.clicked.connect(self.reject)
+        cancelButton.setObjectName("dialogCancel")
+        load_css_for_widget(cancelButton, os.path.join(css_path, 'button.css'))
+
+        mainLayout = QtGui.QVBoxLayout()
+        hbox = QtGui.QHBoxLayout()
+        hbox.addSpacing(80)
+        hbox.addWidget(self.okButton)
+        hbox.addSpacing(20)
+        hbox.addWidget(cancelButton)
+        hbox.addSpacing(80)
+
+        mainLayout.setSpacing(20)
+        mainLayout.addWidget(heading)
+        mainLayout.addWidget(textview)
+        mainLayout.addLayout(hbox)
+
+        self.setLayout(mainLayout)
+
+
+    def addTextEdit(self):
+        textEdit = QtGui.QTextEdit()
+        load_css_for_widget(textEdit, os.path.join(css_path, 'textedit.css'))
+
+        text = self.log
+
+        textEdit.setText(text)
+        textEdit.setReadOnly(True)
+        textEdit.setGeometry(100, 100, 800, 600)
+
+        return textEdit
+
+    def accepted(self):
+        '''
+        This method is used by the BurnerGUI when the user quits the app.
 
         We popup the dialog, wait for the user to click one of the buttons,
         and return whether the user accepted the disclaimer.

--- a/src/osx/burn.py
+++ b/src/osx/burn.py
@@ -74,8 +74,8 @@ def burn_kano_os(path, disk, size, return_queue, report_progress_ui):
     failed = False
     unparsed_line = ''
     try:
-        gzip_cmd = 'gzip -dc {}'.format(path)
-        dd_cmd = 'dd of={} bs=4m'.format(disk)
+        gzip_cmd = "gzip -dc '{}'".format(path)
+        dd_cmd = "dd 'of={}' bs=4m".format(disk)
         gzip_process = subprocess.Popen(gzip_cmd,
                                         env=cmd_env,
                                         stderr=subprocess.PIPE,

--- a/src/osx/dependency.py
+++ b/src/osx/dependency.py
@@ -118,14 +118,14 @@ def get_required_mb():
 
 
 def is_sufficient_space(required_mb):
-    cmd = "df %s | grep -v 'Available' | awk '{print $4}'" % temp_path
+    cmd = "df '%s' | grep -v 'Available' | awk '{print $4}'" % temp_path
     output, _, _ = run_cmd(cmd)
 
     try:
         free_space_mb = float(output.strip()) * 512 / BYTES_IN_MEGABYTE
     except:
         debugger('[ERROR] Failed parsing the line ' + output)
-        return True
+        return False
 
     debugger('Free space {0:.2f} MB in {1}'.format(free_space_mb, temp_path))
     return free_space_mb > required_mb

--- a/src/osx/dependency.py
+++ b/src/osx/dependency.py
@@ -33,7 +33,9 @@ def request_admin_privileges():
     '""".format(os.path.abspath(sys.argv[0]).replace(' ', '\\\\ '))
 
     if os.getuid() != 0:
-        os.system("""osascript -e {}""".format(ask_sudo_osascript))
+        cmd = """osascript -e {}""".format(ask_sudo_osascript)
+        print cmd
+        os.system(cmd)
         sys.exit(0)
 
 


### PR DESCRIPTION
This PR adds support for uploading a log as per https://github.com/KanoComputing/peldins/issues/1946

It also fixes a couple of issues on OSx if the burner is run from a path which contains spaces, and adds logging of unhandled exceptions.

There is probably more logging that should be added, but I did not have time to do that.